### PR TITLE
pathname wasn't being initialized

### DIFF
--- a/lib/refinerycms-inquiries.rb
+++ b/lib/refinerycms-inquiries.rb
@@ -9,6 +9,7 @@ module Refinery
 
       config.after_initialize do
         Refinery::Plugin.register do |plugin|
+          plugin.pathname = root
           plugin.name = "refinery_inquiries"
           plugin.directory = "inquiries"
           plugin.menu_match = /(refinery|admin)\/inquir(ies|y_settings)$/


### PR DESCRIPTION
rake refinery:override view=inquiries/new was failing since the inquiries engine was not registering a pathname and so its views were not found.

FYI the default pathname that was being picked up was in the ActiveSupport gem. I can see two other refinery engines that are picking up the same pathname and I assume it's for the same reason... their real pathname is not being configured during engine initialisation.
