### PR TITLE
Fix against Problems without using refinerycms-i18n

### DIFF
--- a/app/views/admin/inquiry_settings/_confirmation_email_form.html.erb
+++ b/app/views/admin/inquiry_settings/_confirmation_email_form.html.erb
@@ -23,7 +23,7 @@
         <%= "#{RefinerySetting[:site_name]} &lt;no-reply@#{request.domain(RefinerySetting.find_or_set(:tld_length, 1))}&gt;".html_safe %>
       </td>
     </tr>
-    <% RefinerySetting.get("i18n_translation_frontend_locales", :scoping => 'refinery').each do |locale| %>
+    <% (RefinerySetting.get("i18n_translation_frontend_locales", :scoping => 'refinery')||[I18n.locale]).each do |locale| %>
       <tr>
         <td>
           <label class='stripped'><%= t('.subject') %> (<%= locale.to_s %>)</label>


### PR DESCRIPTION
The confirmation form can not filled in if the setting 'i18n_translation_frontend_locales' is nil
