### PR TITLE
Fix rails 3 1 refinery basecontroller

### DIFF
--- a/app/controllers/refinery/admin/inquiries_controller.rb
+++ b/app/controllers/refinery/admin/inquiries_controller.rb
@@ -1,6 +1,6 @@
 module Refinery
   module Admin
-    class InquiriesController < ::Admin::BaseController
+    class InquiriesController < ::Refinery::AdminController
 
       crudify :'refinery/inquiry',
               :title_attribute => "name",

--- a/app/controllers/refinery/admin/inquiry_settings_controller.rb
+++ b/app/controllers/refinery/admin/inquiry_settings_controller.rb
@@ -1,6 +1,6 @@
 module Refinery
   module Admin
-    class InquirySettingsController < ::Admin::BaseController
+    class InquirySettingsController < ::Refinery::AdminController
 
       crudify :'refinery/setting',
               :title_attribute => "name",


### PR DESCRIPTION
``` ruby
Admin::BaseController
```

should be

``` ruby
Refinery::AdminController
```
