### PR TITLE
Positions for page parts.

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -34,7 +34,8 @@ if defined?(::Refinery::Page)
     })
     thank_you_page.parts.create({
       :title => "Body",
-      :body => "<p>We've received your inquiry and will get back to you with a response shortly.</p><p><a href='/'>Return to the home page</a></p>"
+      :body => "<p>We've received your inquiry and will get back to you with a response shortly.</p><p><a href='/'>Return to the home page</a></p>",
+      :position => 0
     })
   end
 
@@ -46,7 +47,8 @@ if defined?(::Refinery::Page)
     })
     privacy_policy_page.parts.create({
       :title => "Body",
-      :body => "<p>We respect your privacy. We do not market, rent or sell our email list to any outside parties.</p><p>We need your e-mail address so that we can ensure that the people using our forms are bona fide. It also allows us to send you e-mail newsletters and other communications, if you opt-in. Your postal address is required in order to send you information and pricing, if you request it.</p><p>Please call us at 123 456 7890 if you have any questions or concerns.</p>"
+      :body => "<p>We respect your privacy. We do not market, rent or sell our email list to any outside parties.</p><p>We need your e-mail address so that we can ensure that the people using our forms are bona fide. It also allows us to send you e-mail newsletters and other communications, if you opt-in. Your postal address is required in order to send you information and pricing, if you request it.</p><p>Please call us at 123 456 7890 if you have any questions or concerns.</p>",
+      :position => 0
     })
   end
 end


### PR DESCRIPTION
Positions removed in 4ab3b57dc35172d95f9b6bb57e45ecb8ec4be8c2, but required for multiple page parts to display in the correct order in the Refinery editor.
