### PR TITLE
Fixes bug with simple quotes being displayed as '&#x27;'

### DIFF
--- a/app/views/refinery/inquiries/inquiry_mailer/notification.text.erb
+++ b/app/views/refinery/inquiries/inquiry_mailer/notification.text.erb
@@ -1,3 +1,5 @@
+<% # encoding: utf-8 %>
+
 <%=raw t('.greeting') %>,
 
 <%=raw t('.you_recieved_new_inquiry') %>
@@ -8,7 +10,7 @@
 <%=raw t('.email') %>: <%= @inquiry.email %>
 <%=raw t('.phone') %>: <%= @inquiry.phone %>
 <%=raw t('.message') %>:
-<%=strip_tags(@inquiry.message) %>
+<%=raw strip_tags(@inquiry.message) %>
 
 <%=raw t('.inquiry_ends') %>
 


### PR DESCRIPTION
I simply added a "raw" in front of the tag stripped message body.

Was it on purpose that it wasn't present ?
