### PR TITLE
Add option to always send notification

### DIFF
--- a/app/controllers/refinery/inquiries/inquiries_controller.rb
+++ b/app/controllers/refinery/inquiries/inquiries_controller.rb
@@ -16,7 +16,7 @@ module Refinery
         @inquiry = ::Refinery::Inquiries::Inquiry.new(params[:inquiry])
 
         if @inquiry.save
-          if @inquiry.ham?
+          if @inquiry.ham? || Refinery::Inquiries.send_notifications_for_inquiries_marked_as_spam
             begin
               ::Refinery::Inquiries::InquiryMailer.notification(@inquiry, request).deliver
             rescue

--- a/lib/generators/refinery/inquiries/templates/config/initializers/refinery/inquiries.rb.erb
+++ b/lib/generators/refinery/inquiries/templates/config/initializers/refinery/inquiries.rb.erb
@@ -7,4 +7,7 @@ Refinery::Inquiries.configure do |config|
 
   # Configure whether to show form field placeholders
   # config.show_placeholders = <%= Refinery::Inquiries.show_placeholders.inspect %>
+
+  # Configure whether inquiries marked as spam should also send a notification mail
+  # config.send_notifications_for_inquiries_marked_as_spam = <%= Refinery::Inquiries.send_notifications_for_inquiries_marked_as_spam.inspect %>
 end

--- a/lib/refinery/inquiries/configuration.rb
+++ b/lib/refinery/inquiries/configuration.rb
@@ -5,9 +5,11 @@ module Refinery
     config_accessor :show_contact_privacy_link
     config_accessor :show_phone_number_field
     config_accessor :show_placeholders
+    config_accessor :send_notifications_for_inquiries_marked_as_spam
 
     self.show_contact_privacy_link = true
     self.show_phone_number_field = true
     self.show_placeholders = true
+    self.send_notifications_for_inquiries_marked_as_spam = false
   end
 end


### PR DESCRIPTION
I made the experience that the spam filter marks real messages as spam. Maybe that happens because it can not really handle german messages. I am not sure, but my simple solution for now is to send always a notification so the user can doublecheck the message.
