### PR TITLE
It'd be better to give a place for user to override `from mail` info

### DIFF
--- a/app/mailers/refinery/inquiries/inquiry_mailer.rb
+++ b/app/mailers/refinery/inquiries/inquiry_mailer.rb
@@ -19,11 +19,11 @@ module Refinery
       end
 
       def from_info
-        "\"#{from_name}\" <#{from_mail}>"
+        "#{from_name} <#{from_mail}>"
       end
 
       def from_name
-        :I18n.t('from_name',
+        ::I18n.t('from_name',
                 :scope => 'refinery.inquiries.config',
                 :site_name => Refinery::Core.site_name,
                 :name => @inquiry.name)


### PR DESCRIPTION
There are some SMTP service have a restriction that the `from mail address` should be same to login account.
It'd be better to have a place for user to override those values.
