### PR TITLE
Fix from header in mail when utf8 characters are used

### DIFF
--- a/app/mailers/refinery/inquiries/inquiry_mailer.rb
+++ b/app/mailers/refinery/inquiries/inquiry_mailer.rb
@@ -6,10 +6,10 @@ module Refinery
         @inquiry = inquiry
         mail :subject   => Refinery::Inquiries::Setting.confirmation_subject(Globalize.locale),
              :to        => inquiry.email,
-             :from      => ::I18n.t('from_name',
+             :from      => '"' + ::I18n.t('from_name',
                                     :scope => 'refinery.inquiries.config',
                                     :site_name => Refinery::Core.site_name,
-                                    :name => @inquiry.name) + " <#{Refinery::Inquiries.from_name}@#{request.domain}>",
+                                    :name => @inquiry.name) + "\" <#{Refinery::Inquiries.from_name}@#{request.domain}>",
              :reply_to  => Refinery::Inquiries::Setting.notification_recipients.split(',').first
       end
 
@@ -17,10 +17,10 @@ module Refinery
         @inquiry = inquiry
         mail :subject   => Refinery::Inquiries::Setting.notification_subject,
              :to        => Refinery::Inquiries::Setting.notification_recipients,
-             :from      => ::I18n.t('from_name',
+             :from      => '"' + ::I18n.t('from_name',
                                     :scope => 'refinery.inquiries.config',
                                     :site_name => Refinery::Core.site_name,
-                                    :name => @inquiry.name) + " <#{Refinery::Inquiries.from_name}@#{request.domain}>",
+                                    :name => @inquiry.name) + "\" <#{Refinery::Inquiries.from_name}@#{request.domain}>",
              :reply_to  => inquiry.email
       end
 


### PR DESCRIPTION
When UTF8 characters are used in name or site name, from header is utf8 encoded but quotes are needed or header will be wrong.

Without quotes I get:

```
=?UTF-8?Q?Pedro_ [Ib=C3=A9rica_de_Sales_S.A.] _ <pedro@example.com>,
    ?=@example.com
```

With quotes I get:

```
=?UTF-8?B?cGl0ZXIgW0liw6lyaWNhIGRlIFNhbGVzIFMuQS5d?= <pedro@example.com>
```

In 2.0 it worked because it was quoted like this:

```
"\"#{Refinery::Core.site_name}\" <no-reply@#{request.domain}>"
```
