### PR TITLE
Avoid smtp server syntax error by replacing brackets with parentheses in from_name

### DIFF
--- a/config/locales/bg.yml
+++ b/config/locales/bg.yml
@@ -6,7 +6,7 @@ bg:
         description: Осигурява форма за контакт и съхранение на запитвания
     inquiries:
       config:
-        from_name: "%{name} [%{site_name}]"
+        from_name: "%{name} (%{site_name})"
       inquiries:
         new:
           send: Изпращане на съобщение

--- a/config/locales/cs.yml
+++ b/config/locales/cs.yml
@@ -6,7 +6,7 @@ cs:
         description: Zajišťuje kontaktní formulář a uchovává zaslané dotazy.
     inquiries:
       config:
-        from_name: "%{name} [%{site_name}]"
+        from_name: "%{name} (%{site_name})"
       inquiries:
         new:
           send: Odeslat zprávu

--- a/config/locales/da.yml
+++ b/config/locales/da.yml
@@ -5,7 +5,7 @@ da:
         title: Henvendelser
     inquiries:
       config:
-        from_name: "%{name} [%{site_name}]"
+        from_name: "%{name} (%{site_name})"
       inquiries:
         new:
           header_message: "Der er et mindre problem"

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -6,7 +6,7 @@ de:
         description: Stellt ein Kontaktformular zur Verfügung und speichert Kontaktanfragen
     inquiries:
       config:
-        from_name: "%{name} [%{site_name}]"
+        from_name: "%{name} (%{site_name})"
       inquiries:
         new:
           send: Nachricht senden

--- a/config/locales/en-GB.yml
+++ b/config/locales/en-GB.yml
@@ -6,7 +6,7 @@ en-GB:
         description: Provides a contact form and stores enquiries
     inquiries:
       config:
-        from_name: "%{name} [%{site_name}]"
+        from_name: "%{name} (%{site_name})"
       inquiries:
         new:
           send: Send message

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -6,7 +6,7 @@ en:
         description: Provides a contact form and stores inquiries
     inquiries:
       config:
-        from_name: "%{name} [%{site_name}]"
+        from_name: "%{name} (%{site_name})"
       inquiries:
         new:
           send: Send message

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -5,7 +5,7 @@ es:
         title: Consultas
     inquiries:
       config:
-        from_name: "%{name} [%{site_name}]"
+        from_name: "%{name} (%{site_name})"
       inquiries:
         new:
           send: Enviar mensaje

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -6,7 +6,7 @@ fr:
         description: Fournit un formulaire de contact et gère les demandes de contacts.
     inquiries:
       config:
-        from_name: "%{name} [%{site_name}]"
+        from_name: "%{name} (%{site_name})"
       inquiries:
         new:
           send: Envoyer un message

--- a/config/locales/it.yml
+++ b/config/locales/it.yml
@@ -6,7 +6,7 @@ it:
         description: Fornisce un modulo di contatto e memorizza le richieste
     inquiries:
       config:
-        from_name: "%{name} [%{site_name}]"
+        from_name: "%{name} (%{site_name})"
       inquiries:
         new:
           header_message: si è verificato un problema

--- a/config/locales/lt.yml
+++ b/config/locales/lt.yml
@@ -6,7 +6,7 @@ lt:
         description: Suteikia kontaktų formą ir saugo užklausas
     inquiries:
       config:
-        from_name: "%{name} [%{site_name}]"
+        from_name: "%{name} (%{site_name})"
       inquiries:
         new:
           send: Siųsti žinutę

--- a/config/locales/lv.yml
+++ b/config/locales/lv.yml
@@ -6,7 +6,7 @@ lv:
         description: Nodrošina kontaktformu un glabā pieprasījumus
     inquiries:
       config:
-        from_name: "%{name} [%{site_name}]"
+        from_name: "%{name} (%{site_name})"
       inquiries:
         new:
           send: Sūtīt ziņu

--- a/config/locales/nb.yml
+++ b/config/locales/nb.yml
@@ -6,7 +6,7 @@ nb:
         description: Legger til et kontaktskjema og lagrer forespørsler
     inquiries:
       config:
-        from_name: "%{name} [%{site_name}]"
+        from_name: "%{name} (%{site_name})"
       inquiries:
         new:
           send: Send melding

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -6,7 +6,7 @@ nl:
         description: Contactformulier en beheer van vragen
     inquiries:
       config:
-        from_name: "%{name} [%{site_name}]"
+        from_name: "%{name} (%{site_name})"
       inquiries:
         new:
           send: Verstuur uw vraag

--- a/config/locales/pl.yml
+++ b/config/locales/pl.yml
@@ -7,7 +7,7 @@ pl:
         article: neutral
     inquiries:
       config:
-        from_name: "%{name} [%{site_name}]"
+        from_name: "%{name} (%{site_name})"
       inquiries:
         new:
           send: Wyślij wiadomość

--- a/config/locales/pt-BR.yml
+++ b/config/locales/pt-BR.yml
@@ -6,7 +6,7 @@ pt-BR:
         description: Gerenciar contatos
     inquiries:
       config:
-        from_name: "%{name} [%{site_name}]"
+        from_name: "%{name} (%{site_name})"
       inquiries:
         new:
           send: Enviar mensagem

--- a/config/locales/ru.yml
+++ b/config/locales/ru.yml
@@ -6,7 +6,7 @@ ru:
         description: Предоставляет форму обратной связи и хранит запросы
     inquiries:
       config:
-        from_name: "%{name} [%{site_name}]"
+        from_name: "%{name} (%{site_name})"
       inquiries:
         new:
           send: Отправить сообщение

--- a/config/locales/sk.yml
+++ b/config/locales/sk.yml
@@ -6,7 +6,7 @@ sk:
         description: Zabezpečuje kontaktný formulár a uchováva zaslané otázky.
     inquiries:
       config:
-        from_name: "%{name} [%{site_name}]"
+        from_name: "%{name} (%{site_name})"
       inquiries:
         new:
           send: Odoslať správu

--- a/config/locales/sl.yml
+++ b/config/locales/sl.yml
@@ -6,7 +6,7 @@ sl:
         description: Priskrbi kontaktni obrazec in shrani povpraševanja
     inquiries:
       config:
-        from_name: "%{name} [%{site_name}]"
+        from_name: "%{name} (%{site_name})"
       inquiries:
         new:
           send: Pošlji sporočilo

--- a/config/locales/sv.yml
+++ b/config/locales/sv.yml
@@ -6,7 +6,7 @@ sv:
         description: Tillhandahåller ett formulär och sparar förfrågningar
     inquiries:
       config:
-        from_name: "%{name} [%{site_name}]"
+        from_name: "%{name} (%{site_name})"
       inquiries:
         new:
           send: Skicka meddelande

--- a/config/locales/zh-CN.yml
+++ b/config/locales/zh-CN.yml
@@ -6,7 +6,7 @@ zh-CN:
         description: 提供一个联系表单与保存咨询
     inquiries:
       config:
-        from_name: "%{name} [%{site_name}]"
+        from_name: "%{name} (%{site_name})"
       inquiries:
         new:
           send: 发送消息


### PR DESCRIPTION
When ActionMailer is configured to use either Gmail or Mailgun as an smtp server, the server returns a syntax error and the email fails to be sent. Replacing the brackets in the `refinery.inquiries.config.from_name` translation with parentheses solves the problem.

Gmail error in production log:

```
Rendered ~/.rvm/gems/ruby-1.9.3-p194@refinery/gems/refinerycms-inquiries-2.1.0/app/views/refinery/inquiries/inquiry_mailer/confirmation.text.erb (15.5ms)

Sent mail to test@domain.com (227.2ms)
There was an error delivering an inquiry confirmation:
555 5.5.2 Syntax error. q2sm11379636qer.22 - gsmtp  
```

Mailgun error in production log:

```
Rendered ~/.rvm/gems/ruby-1.9.3-p194@refinery/gems/refinerycms-inquiries-2.1.0/app/views/refinery/inquiries/inquiry_mailer/confirmation.text.erb (1.3ms)

Sent mail to test@domain.com (374.9ms)
There was an error delivering an inquiry confirmation:
501 Syntax error
```
