### PR TITLE
Use rails 4 strong parameters to be compatible with refinery edge (3.0)

### DIFF
--- a/app/controllers/refinery/inquiries/admin/inquiries_controller.rb
+++ b/app/controllers/refinery/inquiries/admin/inquiries_controller.rb
@@ -44,6 +44,12 @@ module Refinery
           @spam_count = Refinery::Inquiries::Inquiry.where(:spam => true).count
         end
 
+        private
+
+        def inquiry_params
+          params.require(:inquiry).permit(:name, :phone, :message, :email)
+        end
+
       end
     end
   end

--- a/app/controllers/refinery/inquiries/admin/settings_controller.rb
+++ b/app/controllers/refinery/inquiries/admin/settings_controller.rb
@@ -13,7 +13,7 @@ module Refinery
         def update
           @setting = Refinery::Setting.find(params[:id])
 
-          if @setting.update_attributes(params[:setting])
+          if @setting.update_attributes(setting_params)
             flash[:notice] = t('refinery.crudify.updated', :what => @setting.name.gsub("inquiry_", "").titleize)
 
             unless request.xhr? or from_dialog?
@@ -38,6 +38,13 @@ module Refinery
 
         def save_message_for_confirmation
           Refinery::Inquiries::Setting.confirmation_message = params[:message] if params.keys.include?('message')
+        end
+
+      private
+
+        def setting_params
+          params.require(:setting).permit(:title, :name, :value, :destroyable,
+                                            :scoping, :restricted, :form_value_type)
         end
 
       end

--- a/app/controllers/refinery/inquiries/inquiries_controller.rb
+++ b/app/controllers/refinery/inquiries/inquiries_controller.rb
@@ -13,7 +13,7 @@ module Refinery
       end
 
       def create
-        @inquiry = ::Refinery::Inquiries::Inquiry.new(params[:inquiry])
+        @inquiry = ::Refinery::Inquiries::Inquiry.new(inquiry_params)
 
         if @inquiry.save
           if @inquiry.ham? || Refinery::Inquiries.send_notifications_for_inquiries_marked_as_spam
@@ -40,6 +40,12 @@ module Refinery
 
       def find_page
         @page = ::Refinery::Page.find_by_link_url("/contact")
+      end
+
+      private
+
+      def inquiry_params
+        params.require(:inquiry).permit(:name, :phone, :message, :email)
       end
 
     end

--- a/app/models/refinery/inquiries/inquiry.rb
+++ b/app/models/refinery/inquiries/inquiry.rb
@@ -17,8 +17,6 @@ module Refinery
 
       default_scope :order => 'created_at DESC'
 
-      attr_accessible :name, :phone, :message, :email
-
       def self.latest(number = 7, include_spam = false)
         include_spam ? limit(number) : ham.limit(number)
       end


### PR DESCRIPTION
The refinery edge now is incompatible with attr_accessible as of `4729b139452dd3a825b827e90fc96ee9936c37d3`.

This patch makes refinerycms-inquiries use rails 4 strong parameters.
