### PR TITLE
config.show_placeholders = false fix

### DIFF
--- a/app/views/refinery/inquiries/inquiries/new.html.erb
+++ b/app/views/refinery/inquiries/inquiries/new.html.erb
@@ -11,26 +11,26 @@
       <div class="field">
         <%= f.required_label :name, :class => 'placeholder-fallback' %>
         <%= f.text_field :name, :class => 'text', :required => 'required',
-          :placeholder => t('name', :scope => 'activerecord.attributes.refinery/inquiries/inquiry') if Refinery::Inquiries.show_placeholders %>
+          :placeholder => (t('name', :scope => 'activerecord.attributes.refinery/inquiries/inquiry') if Refinery::Inquiries.show_placeholders) %>
       </div>
       <div class="field">
         <%= f.required_label :email, :class => 'placeholder-fallback' %>
         <%= f.email_field :email, :class => 'text email', :required => 'required',
-          :placeholder => t('email', :scope => 'activerecord.attributes.refinery/inquiries/inquiry') if Refinery::Inquiries.show_placeholders %>
+          :placeholder => (t('email', :scope => 'activerecord.attributes.refinery/inquiries/inquiry') if Refinery::Inquiries.show_placeholders) %>
       </div>
 
       <% if Refinery::Inquiries.show_phone_number_field %>
         <div class="field">
           <%= f.label :phone, :class => 'placeholder-fallback' %>
           <%= f.text_field :phone, :class => 'text phone',
-            :placeholder => t('phone', :scope => 'activerecord.attributes.refinery/inquiries/inquiry') if Refinery::Inquiries.show_placeholders %>
+            :placeholder => (t('phone', :scope => 'activerecord.attributes.refinery/inquiries/inquiry') if Refinery::Inquiries.show_placeholders) %>
         </div>
       <% end %>
 
       <div class='field message_field'>
         <%= f.required_label :message, :class => 'placeholder-fallback' %>
         <%= f.text_area :message, :rows => 8, :required => 'required',
-          :placeholder => t('message', :scope => 'activerecord.attributes.refinery/inquiries/inquiry') if Refinery::Inquiries.show_placeholders %>
+          :placeholder => (t('message', :scope => 'activerecord.attributes.refinery/inquiries/inquiry') if Refinery::Inquiries.show_placeholders) %>
       </div>
       <div class="actions">
         <%= f.submit t('.send') %>


### PR DESCRIPTION
config.show_placeholders only should hide the placeholder. Nor the input field too.
Condition now only evaluates :placeholder option.
