### PR TITLE
Require filter_spam in lib instead of in model

### DIFF
--- a/app/models/refinery/inquiries/inquiry.rb
+++ b/app/models/refinery/inquiries/inquiry.rb
@@ -1,5 +1,4 @@
 require 'refinery/core/base_model'
-require 'filters_spam'
 
 module Refinery
   module Inquiries

--- a/lib/refinery/inquiries.rb
+++ b/lib/refinery/inquiries.rb
@@ -1,5 +1,6 @@
 require 'refinerycms-core'
 require 'refinerycms-settings'
+require 'filters_spam'
 
 module Refinery
   autoload :InquiriesGenerator, 'generators/refinery/inquiries/inquiries_generator'


### PR DESCRIPTION
I'm doing the same of RefineryCMS Blog and it looks cleaner : 
https://github.com/refinery/refinerycms-blog/search?utf8=%E2%9C%93&q=filters_spam