### PR TITLE
Add support for refinerycms-core 4.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,4 +25,6 @@ env:
   - DB=postgresql
   - DB=mysql
 rvm:
-  - 2.3.3
+  - 2.4.2
+  - 2.3.5
+  - 2.2.8

--- a/Gemfile
+++ b/Gemfile
@@ -2,12 +2,20 @@ source 'https://rubygems.org'
 
 gemspec
 
-gem 'refinerycms', ["~> 3.0", ">= 3.0.3"]
-gem 'refinerycms-settings', "~> 3.0"
+git "https://github.com/refinery/refinerycms", branch: "master" do
+  gem "refinerycms"
+
+  group :test do
+    gem "refinerycms-testing"
+  end
+end
+
+group :development do
+  gem 'listen'
+end
 
 group :test do
-  gem 'refinerycms-testing', ["~> 3.0", ">= 3.0.3"]
-  gem 'capybara-email', '~> 2.4.0'
+  gem 'capybara-email', '~> 2.5'
   gem 'poltergeist'
 end
 
@@ -29,8 +37,11 @@ if !ENV['TRAVIS'] || ENV['DB'] == 'postgresql'
 end
 
 # Refinery/rails should pull in the proper versions of these
-gem 'sass-rails'
-gem 'coffee-rails'
+group :assets do
+  gem "sass-rails"
+  gem "coffee-rails"
+  gem "uglifier"
+end
 
 # Load local gems according to Refinery developer preference.
 if File.exist? local_gemfile = File.expand_path('../.gemfile', __FILE__)

--- a/app/controllers/refinery/inquiries/admin/inquiries_controller.rb
+++ b/app/controllers/refinery/inquiries/admin/inquiries_controller.rb
@@ -27,7 +27,7 @@ module Refinery
           find_inquiry
           @inquiry.toggle!(:spam)
 
-          redirect_to :back
+          redirect_back fallback_location: root_path
         end
 
         protected

--- a/app/controllers/refinery/inquiries/admin/settings_controller.rb
+++ b/app/controllers/refinery/inquiries/admin/settings_controller.rb
@@ -16,7 +16,7 @@ module Refinery
           unless request.xhr? or from_dialog?
             redirect_back_or_default(refinery.inquiries_admin_inquiries_path)
           else
-            render text: "<script type='text/javascript'>parent.window.location = '#{refinery.inquiries_admin_inquiries_path}';</script>"
+            render html: "<script type='text/javascript'>parent.window.location = '#{refinery.inquiries_admin_inquiries_path}';</script>".html_safe
           end
         end
 

--- a/bin/rails
+++ b/bin/rails
@@ -1,5 +1,11 @@
 #!/usr/bin/env ruby
-# This command will automatically be run when you run "rails" with Rails 3 gems installed from the root of your application.
+# This command will automatically be run when you run "rails" with Rails gems
+# installed from the root of your application.
 
-ENGINE_PATH = File.expand_path('../..',  __FILE__)
-load File.expand_path('../../spec/dummy/bin/rails',  __FILE__)
+begin
+  load File.join(File.expand_path('../../',  __FILE__), 'spec/dummy/bin/rails')
+rescue LoadError => load_error
+  warn "No dummy Rails application found! \n" \
+       "To create one in spec/dummy, please run: \n\n" \
+       "    rake refinery:testing:dummy_app"
+end

--- a/db/migrate/20101208082840_create_inquiries.rb
+++ b/db/migrate/20101208082840_create_inquiries.rb
@@ -1,4 +1,4 @@
-class CreateInquiries < ActiveRecord::Migration
+class CreateInquiries < ActiveRecord::Migration[4.2]
   def up
     unless ::Refinery::Inquiries::Inquiry.table_exists?
       create_table :refinery_inquiries_inquiries, :force => true do |t|

--- a/refinerycms-inquiries.gemspec
+++ b/refinerycms-inquiries.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |s|
   s.name            = %q{refinerycms-inquiries}
-  s.version         = %q{3.1.0}
+  s.version         = %q{4.0.0}
   s.summary         = %q{Inquiry handling functionality for the Refinery CMS project.}
   s.description     = %q{Inquiry handling functionality extracted from Refinery CMS to allow you to have a contact form and manage inquiries in the Refinery backend.}
   s.homepage        = %q{http://refinerycms.com}
@@ -14,10 +14,10 @@ Gem::Specification.new do |s|
   s.files           = `git ls-files`.split("\n")
   s.test_files      = `git ls-files -- spec/*`.split("\n")
 
-  s.add_dependency  'refinerycms-core',     '~> 3.0.0'
-  s.add_dependency  'refinerycms-settings', '~> 3.0.0'
+  s.add_dependency  'refinerycms-core',     '~> 4.0'
+  s.add_dependency  'refinerycms-settings', '~> 4.0'
   s.add_dependency  'filters_spam',         '~> 0.2'
-  s.add_dependency  'actionmailer',        '~> 4.2.4'
+  s.add_dependency  'actionmailer',        ['>= 5.1.0', '< 5.2']
   s.add_dependency  'httpclient'
 
   s.cert_chain      = [File.expand_path("../certs/parndt.pem", __FILE__)]

--- a/spec/features/refinery/inquiries/mailer_spec.rb
+++ b/spec/features/refinery/inquiries/mailer_spec.rb
@@ -7,6 +7,7 @@ module Refinery
       before do
         FactoryGirl.create(:page, :link_url => Refinery::Inquiries.page_path_new)
 
+        allow(ActionMailer::Base).to receive(:delivery_method).and_return(:test)
         allow(Refinery::Inquiries::Setting).to receive(:notification_recipients)
           .and_return("rspec@refinerycms.com")
 


### PR DESCRIPTION
Note: Specs will not fail after the release of refinerycms-settings for 4.0