### PR TITLE
Add optional company field in inquiry form

### DIFF
--- a/app/controllers/refinery/inquiries/inquiries_controller.rb
+++ b/app/controllers/refinery/inquiries/inquiries_controller.rb
@@ -41,7 +41,7 @@ module Refinery
       private
 
       def permitted_inquiry_params
-        [:name, :phone, :message, :email]
+        [:name, :company, :phone, :message, :email]
       end
 
       def inquiry_saved_and_validated?

--- a/app/models/refinery/inquiries/inquiry.rb
+++ b/app/models/refinery/inquiries/inquiry.rb
@@ -9,7 +9,7 @@ module Refinery
         filters_spam message_field:    :message,
                      email_field:      :email,
                      author_field:     :name,
-                     other_fields:     [:phone],
+                     other_fields:     [:phone, :company],
                      extra_spam_words: %w()
       end
 

--- a/app/views/refinery/inquiries/admin/inquiries/show.html.erb
+++ b/app/views/refinery/inquiries/admin/inquiries/show.html.erb
@@ -46,6 +46,16 @@
         <%= @inquiry.name %> [<%= mail_to @inquiry.email, @inquiry.email, {:title => t('.click_to_email')} %>]
       </td>
     </tr>
+    <% unless @inquiry.company.blank? %>
+      <tr>
+        <td>
+          <strong><%= t('.company') %></strong>
+        </td>
+        <td>
+          <%= @inquiry.company %>
+        </td>
+      </tr>
+    <% end %>
     <% unless @inquiry.phone.blank? %>
       <tr>
         <td>

--- a/app/views/refinery/inquiries/inquiries/_form.html.erb
+++ b/app/views/refinery/inquiries/inquiries/_form.html.erb
@@ -11,6 +11,14 @@
       :placeholder => (t('name', :scope => 'activerecord.attributes.refinery/inquiries/inquiry') if Refinery::Inquiries.show_placeholders) %>
   </div>
 
+  <% if Refinery::Inquiries.show_company_field %>
+    <div class="field">
+      <%= f.label :company, :class => 'placeholder-fallback' %>
+      <%= f.text_field :company, :class => 'text company',
+        :placeholder => (t('company', :scope => 'activerecord.attributes.refinery/inquiries/inquiry') if Refinery::Inquiries.show_placeholders) %>
+    </div>
+  <% end %>
+
   <div class="field">
     <%= f.label :email, :class => 'placeholder-fallback required' %>
     <%= f.email_field :email, :class => 'text email', :required => 'required',

--- a/app/views/refinery/inquiries/inquiry_mailer/notification.text.erb
+++ b/app/views/refinery/inquiries/inquiry_mailer/notification.text.erb
@@ -5,6 +5,7 @@
 <%=raw t('.inquiry_starts') %>
 
 <%=raw t('.from') %>: <%= @inquiry.name %>
+<%=raw t('.company') %>: <%= @inquiry.company %>
 <%=raw t('.email') %>: <%= @inquiry.email %>
 <%=raw t('.phone') %>: <%= @inquiry.phone %>
 <%=raw t('.message') %>:

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -38,6 +38,7 @@ de:
             to: An
             from: Von
             click_to_email: Klicken, um eine E-Mail an diese Adresse zu schicken
+            company: Firma
             phone: Telefon
             date: Datum
             message: Nachricht
@@ -65,6 +66,7 @@ de:
           inquiry_ends: --- Ende der Kontaktanfrage ---
           from: Von
           email: E-Mail
+          company: Firma
           phone: Telefon
           message: Nachricht
           closing_line: Mit freundlichen Grüßen
@@ -76,5 +78,6 @@ de:
       refinery/inquiries/inquiry:
         name: Name
         email: E-Mail
+        company: Firma
         phone: Telefon
         message: Nachricht

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -40,6 +40,7 @@ en:
             to: To
             from: From
             click_to_email: Click to email this address
+            company: Company
             phone: Phone
             date: Date
             message: Message
@@ -65,6 +66,7 @@ en:
           inquiry_starts: --- inquiry starts ---
           inquiry_ends: --- inquiry ends ---
           from: From
+          company: Company
           email: Email
           phone: Phone
           message: Message
@@ -76,6 +78,7 @@ en:
     attributes:
       refinery/inquiries/inquiry:
         name: Name
+        company: Company
         email: Email
         phone: Phone
         message: Message

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -40,6 +40,7 @@ fr:
             to: À
             from: De
             click_to_email: Cliquer ici pour enyoyer un e-mail à cette adresse
+            company: Compagnie
             phone: Téléphone
             date: Date
             message: Message
@@ -67,6 +68,7 @@ fr:
           inquiry_ends: --- Fin des requêtes ---
           from: De
           email: E-mail
+          company: Compagnie
           phone: Téléphone
           message: Message
           closing_line: Cordialement
@@ -78,5 +80,6 @@ fr:
       refinery/inquiries/inquiry:
         name: Nom
         email: E-mail
+        company: Compagnie
         phone: Téléphone
         message: Message

--- a/db/migrate/20180613201543_add_company_to_refinery_inquiries_inquiry.rb
+++ b/db/migrate/20180613201543_add_company_to_refinery_inquiries_inquiry.rb
@@ -1,0 +1,9 @@
+class AddCompanyToRefineryInquiriesInquiry < ActiveRecord::Migration[4.2]
+  def up
+    add_column :refinery_inquiries_inquiries, :company, :string
+  end
+
+  def down
+    remove_column :refinery_inquiries_inquiries, :company
+  end
+end

--- a/lib/generators/refinery/inquiries/templates/config/initializers/refinery/inquiries.rb.erb
+++ b/lib/generators/refinery/inquiries/templates/config/initializers/refinery/inquiries.rb.erb
@@ -2,6 +2,9 @@ Refinery::Inquiries.configure do |config|
   # Configure whether to show privacy link
   # config.show_contact_privacy_link = <%= Refinery::Inquiries.show_contact_privacy_link.inspect %>
 
+  # Configure whether to show company field
+  # config.show_company_field = <%= Refinery::Inquiries.show_company_field.inspect %>
+
   # Configure whether to show phone number field
   # config.show_phone_number_field = <%= Refinery::Inquiries.show_phone_number_field.inspect %>
 

--- a/lib/refinery/inquiries/configuration.rb
+++ b/lib/refinery/inquiries/configuration.rb
@@ -3,6 +3,7 @@ module Refinery
     include ActiveSupport::Configurable
 
     config_accessor :show_contact_privacy_link
+    config_accessor :show_company_field
     config_accessor :show_phone_number_field
     config_accessor :show_placeholders
     config_accessor :send_notifications_for_inquiries_marked_as_spam
@@ -11,6 +12,7 @@ module Refinery
     config_accessor :filter_spam, :recaptcha_site_key
 
     self.show_contact_privacy_link = true
+    self.show_company_field = false
     self.show_phone_number_field = true
     self.show_placeholders = true
     self.send_notifications_for_inquiries_marked_as_spam = false

--- a/spec/features/refinery/inquiries/inquiries_spec.rb
+++ b/spec/features/refinery/inquiries/inquiries_spec.rb
@@ -51,6 +51,7 @@ module Refinery
           expect(page).to have_content(email_error_message)
           expect(page).to have_content(message_error_message)
           expect(page).to have_no_content("Phone can't be blank")
+          expect(page).to have_no_content("Company can't be blank")
 
           expect(Refinery::Inquiries::Inquiry.count).to eq(0)
         end
@@ -142,6 +143,34 @@ module Refinery
 
             expect(page).to have_selector("label", :text => 'Phone')
             expect(page).to have_selector("#inquiry_phone")
+          end
+        end
+      end
+
+      describe "company" do
+        context "when show company setting set to false" do
+          before(:each) do
+            allow(Refinery::Inquiries.config).to receive(:show_company_field).and_return(false)
+          end
+
+          it "won't show company" do
+            visit refinery.inquiries_new_inquiry_path
+
+            expect(page).to have_no_selector("label", :text => 'Company')
+            expect(page).to have_no_selector("#inquiry_company")
+          end
+        end
+
+        context "when show company setting set to true" do
+          before(:each) do
+            allow(Refinery::Inquiries.config).to receive(:show_company_field).and_return(true)
+          end
+
+          it "shows the company" do
+            visit refinery.inquiries_new_inquiry_path
+
+            expect(page).to have_selector("label", :text => 'Company')
+            expect(page).to have_selector("#inquiry_company")
           end
         end
       end


### PR DESCRIPTION
For a specific project's contact form I needed also to have an extra input field for the company of the person sending an inquiry so I added this feature in this PR. Similar to the phone input field, the company field has its own config setting where it can be turned on or off (default is false => not used). The only part missing here should be the additional locales (I only did en, de and fr), hopefully nothing else is missing, else simply let me know. Thank you in advance for considering this PR.