### PR TITLE
Add support for flash notice

### DIFF
--- a/app/controllers/refinery/inquiries/admin/settings_controller.rb
+++ b/app/controllers/refinery/inquiries/admin/settings_controller.rb
@@ -4,7 +4,7 @@ module Refinery
       class SettingsController < Refinery::AdminController
 
         before_action :find_setting, :only => [:edit, :update]
-        after_action :save_subject_for_confirmation,
+        after_action :save_subject_for_confirmation, :save_flash_notice,
           :save_message_for_confirmation, :save_notification_recipients, :only => :update
 
         def edit
@@ -50,12 +50,19 @@ module Refinery
           end
         end
 
+        def save_flash_notice
+          if setting_params.include?('notice')
+            Refinery::Inquiries::Setting.flash_notice = setting_params[:notice]
+          end
+        end
+
       private
 
         def setting_params
           params.require(:setting).permit(:value,
             subject: Refinery::I18n.frontend_locales,
-            message: Refinery::I18n.frontend_locales)
+            message: Refinery::I18n.frontend_locales,
+            notice: Refinery::I18n.frontend_locales)
         end
 
       end

--- a/app/controllers/refinery/inquiries/inquiries_controller.rb
+++ b/app/controllers/refinery/inquiries/inquiries_controller.rb
@@ -18,6 +18,9 @@ module Refinery
         @inquiry = Inquiry.new(inquiry_params)
 
         if inquiry_saved_and_validated?
+          if Refinery::Inquiries.show_flash_notice
+            flash[:notice] = Refinery::Inquiries::Setting.flash_notice
+          end
           redirect_to refinery.thank_you_inquiries_inquiries_path
         else
           render action: 'new'

--- a/app/models/refinery/inquiries/setting.rb
+++ b/app/models/refinery/inquiries/setting.rb
@@ -40,6 +40,22 @@ module Refinery
           end
         end
 
+        def flash_notice(locale='en')
+          find_or_set(:"inquiry_flash_notice_#{locale}",
+            "Thank you very much for your inquiry. We will get back to you shortly.",
+            scoping: "inquiries"
+          )
+        end
+
+        def flash_notice=(locales_notices)
+          locales_notices.each do |locale, notice|
+            set(:"inquiry_flash_notice_#{locale}", {
+              value: notice,
+              scoping: "inquiries"
+            })
+          end
+        end
+
         def notification_recipients
           recipients = ((Role[:refinery].users.first.email rescue nil) if defined?(Role)).to_s
           find_or_set(:inquiry_notification_recipients, recipients, scoping: "inquiries")

--- a/lib/generators/refinery/inquiries/templates/config/initializers/refinery/inquiries.rb.erb
+++ b/lib/generators/refinery/inquiries/templates/config/initializers/refinery/inquiries.rb.erb
@@ -11,6 +11,9 @@ Refinery::Inquiries.configure do |config|
   # Configure whether to show form field placeholders
   # config.show_placeholders = <%= Refinery::Inquiries.show_placeholders.inspect %>
 
+  # Configure whether to show flash notice after submitting inquiry
+  # config.show_flash_notice = <%= Refinery::Inquiries.show_flash_notice.inspect %>
+
   # Configure whether inquiries marked as spam should also send a notification mail
   # config.send_notifications_for_inquiries_marked_as_spam = <%= Refinery::Inquiries.send_notifications_for_inquiries_marked_as_spam.inspect %>
 

--- a/lib/refinery/inquiries/configuration.rb
+++ b/lib/refinery/inquiries/configuration.rb
@@ -6,6 +6,7 @@ module Refinery
     config_accessor :show_company_field
     config_accessor :show_phone_number_field
     config_accessor :show_placeholders
+    config_accessor :show_flash_notice
     config_accessor :send_notifications_for_inquiries_marked_as_spam
     config_accessor :from_name
     config_accessor :post_path, :page_path_new, :page_path_thank_you
@@ -15,6 +16,7 @@ module Refinery
     self.show_company_field = false
     self.show_phone_number_field = true
     self.show_placeholders = true
+    self.show_flash_notice = false
     self.send_notifications_for_inquiries_marked_as_spam = false
     self.from_name = "no-reply"
     self.post_path = "/contact"


### PR DESCRIPTION
This PR adds support for a simple flash notice after having submitted the inquiry form. For example instead of using the thank you page one can redirect to any other page and display that flash notice in the page template using the Rails way `<%= flash[:notice] %>`.

For that purpose I added a config parameter `show_flash_notice` which enables or disables the flash notice (default is disabled) along with a new setting (Inquiry Flash Notice En (Inquiries)) in order to set the content of that notice.

I did not add any UT as this would require a page with a flash notice.

Feel free to let me know if my code needs any modifications or if I missed something.